### PR TITLE
Set up GitHub Actions for Smalltalk CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,10 @@ jobs:
           gcc -c unqlite.c
           gcc -shared -o unqlite.so unqlite.o
           cd ..
+          # Copy library to multiple locations for maximum compatibility
           cp unqlite-src/unqlite.so .
+          sudo cp unqlite-src/unqlite.so /usr/local/lib/
+          sudo ldconfig
           ls -lh unqlite.so
 
       - name: Setup smalltalkCI
@@ -44,7 +47,13 @@ jobs:
           smalltalk-image: ${{ matrix.smalltalk }}
 
       - name: Run tests
-        run: smalltalkci -s ${{ matrix.smalltalk }}
+        run: |
+          # Verify library exists and set library path
+          ls -lh unqlite.so
+          pwd
+          export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+          smalltalkci -s ${{ matrix.smalltalk }}
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: smalltalkCI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        smalltalk:
+          - Pharo64-12
+          - Pharo64-13
+        experimental: [false]
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc make
+
+      - name: Download UnQLite source
+        run: |
+          curl -L -o unqlite.zip https://github.com/symisc/unqlite/archive/refs/heads/master.zip
+          unzip unqlite.zip
+          mv unqlite-master unqlite-src
+
+      - name: Compile UnQLite library
+        run: |
+          cd unqlite-src
+          gcc -c unqlite.c
+          gcc -shared -o unqlite.so unqlite.o
+          cd ..
+          cp unqlite-src/unqlite.so .
+          ls -lh unqlite.so
+
+      - name: Setup smalltalkCI
+        uses: hpi-swa/setup-smalltalkCI@v1
+        with:
+          smalltalk-image: ${{ matrix.smalltalk }}
+
+      - name: Run tests
+        run: smalltalkci -s ${{ matrix.smalltalk }}
+        timeout-minutes: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         smalltalk:
-          - Pharo64-12
           - Pharo64-13
         experimental: [false]
     continue-on-error: ${{ matrix.experimental }}
@@ -46,14 +45,24 @@ jobs:
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
 
-      - name: Run tests
+      - name: Copy UnQLite library to build directory
         run: |
-          # Verify library exists and set library path
-          ls -lh unqlite.so
-          pwd
-          export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-          smalltalkci -s ${{ matrix.smalltalk }}
+          # Source smalltalkCI environment
+          source ~/.bashrc || true
+          source $HOME/.smalltalk_ci.env || true
+
+          # Check if SMALLTALK_CI_BUILD_BASE is set, otherwise use default
+          if [ -z "$SMALLTALK_CI_BUILD_BASE" ]; then
+            export SMALLTALK_CI_BUILD_BASE="$HOME/.smalltalkCI/_builds"
+          fi
+
+          echo "SMALLTALK_CI_BUILD_BASE=$SMALLTALK_CI_BUILD_BASE"
+          mkdir -p "$SMALLTALK_CI_BUILD_BASE"
+          cp unqlite.so "$SMALLTALK_CI_BUILD_BASE/"
+          ls -lh "$SMALLTALK_CI_BUILD_BASE/unqlite.so"
+
+      - name: Run tests
+        run: smalltalkci -s ${{ matrix.smalltalk }}
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         smalltalk:
+          - Pharo64-12
           - Pharo64-13
         experimental: [false]
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,6 @@ jobs:
           cd unqlite-src
           gcc -c unqlite.c
           gcc -shared -o unqlite.so unqlite.o
-          cd ..
-          # Copy library to multiple locations for maximum compatibility
-          cp unqlite-src/unqlite.so .
-          sudo cp unqlite-src/unqlite.so /usr/local/lib/
-          sudo ldconfig
           ls -lh unqlite.so
 
       - name: Setup smalltalkCI
@@ -59,7 +54,7 @@ jobs:
 
           echo "SMALLTALK_CI_BUILD_BASE=$SMALLTALK_CI_BUILD_BASE"
           mkdir -p "$SMALLTALK_CI_BUILD_BASE"
-          cp unqlite.so "$SMALLTALK_CI_BUILD_BASE/"
+          cp unqlite-src/unqlite.so "$SMALLTALK_CI_BUILD_BASE/"
           ls -lh "$SMALLTALK_CI_BUILD_BASE/unqlite.so"
 
       - name: Run tests

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,0 +1,11 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'PunQLite',
+      #directory : 'repository',
+      #load : [ 'Tests' ],
+      #onConflict : #useLoaded,
+      #platforms : [ #pharo ]
+    }
+  ]
+}


### PR DESCRIPTION
- Add .smalltalk.ston configuration for SmalltalkCI
- Add GitHub Actions workflow (.github/workflows/main.yml)
- Test on Pharo 12 and 13 with Ubuntu 22.04
- Automatically download and compile UnQLite library from source
- Run tests via smalltalkCI