### PR TITLE
Remove unnecessary flag from Windows compilation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gcc -dynamiclib -o unqlite.dylib unqlite.o
 **Windows (MinGW):**
 ```bash
 gcc -c unqlite.c
-gcc -shared -static-libgcc -o unqlite.dll unqlite.o -Wl,--add-stdcall-alias
+gcc -shared -static-libgcc -o unqlite.dll unqlite.o
 ```
 
 **Note:** For 32-bit systems, add the `-m32` option to both gcc commands.

--- a/repository/BaselineOfPunQLite/BaselineOfPunQLite.class.st
+++ b/repository/BaselineOfPunQLite/BaselineOfPunQLite.class.st
@@ -31,10 +31,11 @@ BaselineOfPunQLite >> baseline: spec [
 { #category : #accessing }
 BaselineOfPunQLite >> platformLibraryName [
 	" Answer a name for the compiled version of the library "
-
-	Smalltalk os isUnix ifTrue: [ ^ 'unqlite.so' ].
-	Smalltalk os isWin32 ifTrue: [ ^ 'unqlite.dll' ].
-	Smalltalk os isMacOSX ifTrue: [ ^ 'unqlite.dylib' ].
+	| os |
+	os := Smalltalk os.
+	os isUnix ifTrue: [ ^ 'unqlite.so' ].
+	os isWindows ifTrue: [ ^ 'unqlite.dll' ].
+	os isMacOSX ifTrue: [ ^ 'unqlite.dylib' ].
 	
 	self error: 'Unsupported OS platform'
 ]


### PR DESCRIPTION
- Refactor platformLibraryName method for better OS handling