### PR TITLE
Migrate PqDatabaseBrowser to Spec2 for Pharo 13 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Claude
+.claude/
+.claudedocs/

--- a/repository/PunQLite-Tools/PqDatabaseBrowser.class.st
+++ b/repository/PunQLite-Tools/PqDatabaseBrowser.class.st
@@ -1,275 +1,203 @@
 "
-A database browser
+A database browser for PunQLite
 
 Instance Variables
-	menu:		<Object>
-
-menu
-	- xxxxx
+	database:			<PqDatabase> The database being browsed
+	keysList:			<SpFilteringListPresenter> List of keys with filter
+	toolbar:			<SpToolbarPresenter> Toolbar with action buttons
+	valueText:			<SpTextPresenter> Text display for selected value
+	databaseFilename:	<String> Path to opened database file
 
 "
 Class {
 	#name : #PqDatabaseBrowser,
-	#superclass : #ComposableModel,
+	#superclass : #SpPresenter,
 	#instVars : [
 		'database',
-		'keysModel',
-		'menu',
-		'valueModel',
+		'keysList',
+		'toolbar',
+		'valueText',
 		'databaseFilename'
 	],
 	#category : 'PunQLite-Tools-UI'
 }
 
-{ #category : #'private - specs' }
-PqDatabaseBrowser class >> contentSpec [ 
- 	<spec: #content>
- 
-	^SpecLayout composed
-		  newRow: [:row |  
-					row add: self leftSpec;
-					addSplitter;
-					add:  #valueModel ] 
-]
-
-{ #category : #'private - specs' }
-PqDatabaseBrowser class >> defaultSpec [
-	<spec>
-	
-	^ SpecLayout composed
-		newColumn: [ :c | 
-			c 
-				add: #menu height: self toolbarHeight;
-				add: self contentSpec ];	
-		yourself
-]
-
 { #category : #examples }
 PqDatabaseBrowser class >> example1 [
+	<example>
 
 	self open
-]
-
-{ #category : #'private - specs' }
-PqDatabaseBrowser class >> leftSpec [
-  	<spec>
- 
-	| searchBarOffset delta |
-	searchBarOffset := 5 + StandardFonts defaultFont height + 10.
-	delta := 25.
-	^SpecLayout composed 
-		add: #keysModel origin: 0@0 corner: 1@1 offsetOrigin: 0@searchBarOffset offsetCorner: 0@0;
-		add: #keysSearchField origin: 0@0 corner: 1@0 offsetOrigin: 0@0 offsetCorner: 0@searchBarOffset
 ]
 
 { #category : #menu }
 PqDatabaseBrowser class >> menuCommandOn: aBuilder [
 
-	<worldMenu>		 
-		
+	<worldMenu>
+
 	(aBuilder item: #'Database Browser')
 		parent: #'PunQLite';
 		order: 1;
-		action:[ self open ]; 
+		action:[ self open ];
 		icon: self taskbarIcon.
 ]
 
 { #category : #'instance creation' }
 PqDatabaseBrowser class >> open [
 	<script>
-	
-	^(self new)  
-		openWithSpec;
-		yourself
+
+	^ self new open
 ]
 
 { #category : #menu }
 PqDatabaseBrowser class >> taskbarIcon [
 
-	^PqToolIcons iconNamed: #databaseConnectIcon
+	^ PqToolIcons iconNamed: #databaseConnectIcon
 ]
 
 { #category : #accessing }
 PqDatabaseBrowser >> database [
 
-	^database
+	^ database
 ]
 
-{ #category : #'private - events' }
-PqDatabaseBrowser >> delete [
+{ #category : #layout }
+PqDatabaseBrowser >> defaultLayout [
 
-	database ifNotNil: [ database close. databaseFile := nil ].
-	super delete.
-]
-
-{ #category : #initialization }
-PqDatabaseBrowser >> initialExtent [
-
-	^600@460
-]
-
-{ #category : #initialization }
-PqDatabaseBrowser >> initializeMenu [
-
-	menu := MenuModel new
-		addGroup: [ :group |			 
-			group addItem: [ :item |
-				item
-					name: nil;
-					description: 'Open file';
-					icon: (PqToolIcons iconNamed: #databaseConnectIcon);
-					action: [ self openFile ] ].
-				
-			group addItem: [ :item |
-				item
-					name: nil;
-					description: 'Edit entry';
-					icon: (PqToolIcons iconNamed: #databaseEditIcon);
-					action: [ self onEditEntry ] ].				
-
-			group addItem: [ :item |
-				item
-					name: nil;
-					description: 'Add entry';
-					icon: (PqToolIcons iconNamed: #databaseAddIcon);
-					action: [ self onAddEntry ] ].				   
-			 
-			group addItem: [ :item |
-				item
-					name: nil;
-					description: 'Remove entry';
-					icon: (PqToolIcons iconNamed: #databaseRemoveIcon);
-					action: [ self onRemoveSelectedEntry ]].	
-								
-			group addItem: [ :item |
-				item 
-					name: nil;
-					description: 'Help';
-					icon: Smalltalk ui icons smallHelpIcon;
-					action: [ self openHelp ] ].		
-		].
-		
-	menu applyTo: self.
+	^ SpBoxLayout newTopToBottom
+		add: #toolbar withConstraints: [ :c | c height: self class toolbarHeight ];
+		add: (SpPanedLayout newLeftToRight
+			add: #keysList;
+			add: #valueText;
+			yourself);
+		yourself
 ]
 
 { #category : #initialization }
-PqDatabaseBrowser >> initializeWidgets [
+PqDatabaseBrowser >> initializePresenters [
 
-	self initializeMenu.
-	keysModel := self instantiate: IconListModel.
-	keysModel 
-			menu: [:aMenu | self keysListMenu: aMenu];
-	 		whenSelectionChanged: [ self onKeySelectionChanged ].
-	valueModel := self newText.
-	self focusOrder add: valueModel
+	self initializeToolbar.
+
+	keysList := self instantiate: SpFilteringListPresenter.
+	keysList
+		items: #();
+		display: [ :item | item ];
+		matchSubstring;
+		contextMenu: [ self keysListContextMenu ];
+		whenSelectionChangedDo: [ :selection | self onKeySelectionChanged ].
+
+	valueText := self newText.
+	valueText editable: false
 ]
 
-{ #category : #'private - filtering' }
-PqDatabaseBrowser >> keysFilterPattern: aRxMatcher [ 
-	 
-	 self keysModel items: 
-		(aRxMatcher isNil ifTrue: [self database keys ]
-					    ifFalse: [ self database keys select: [ :each| aRxMatcher search: each asString ]]).
+{ #category : #initialization }
+PqDatabaseBrowser >> initializeToolbar [
 
-	 
+	toolbar := self newToolbar.
+
+	toolbar add: (SpToolbarButtonPresenter new
+		label: 'Open';
+		icon: (PqToolIcons iconNamed: #databaseConnectIcon);
+		help: 'Open database file';
+		action: [ self openFile ];
+		yourself).
+
+	toolbar add: (SpToolbarButtonPresenter new
+		label: 'Edit';
+		icon: (PqToolIcons iconNamed: #databaseEditIcon);
+		help: 'Edit entry';
+		action: [ self onEditEntry ];
+		yourself).
+
+	toolbar add: (SpToolbarButtonPresenter new
+		label: 'Add';
+		icon: (PqToolIcons iconNamed: #databaseAddIcon);
+		help: 'Add entry';
+		action: [ self onAddEntry ];
+		yourself).
+
+	toolbar add: (SpToolbarButtonPresenter new
+		label: 'Remove';
+		icon: (PqToolIcons iconNamed: #databaseRemoveIcon);
+		help: 'Remove entry';
+		action: [ self onRemoveSelectedEntry ];
+		yourself)
 ]
 
-{ #category : #'private - menues' }
-PqDatabaseBrowser >> keysListMenu: aMenu [
+{ #category : #initialization }
+PqDatabaseBrowser >> initializeWindow: aWindowPresenter [
 
-	aMenu target: self.
-	aMenu addTitle:  'Entry'.
-	aMenu add: 'Add entry' selector: #onAddSelectedEntry.			 
-	keysModel selectedItem ifNotNil: [ 
-		aMenu add: 'Remove entry' selector: #onRemoveSelectedEntry.		
-	].
-	aMenu addLine.
-	aMenu add: 'Edit entry' selector: #onEditEntry.
-	^aMenu
-]
-
-{ #category : #accessing }
-PqDatabaseBrowser >> keysModel [
-
-	^keysModel
-]
-
-{ #category : #accessing }
-PqDatabaseBrowser >> keysModel: anObject [
-
-	keysModel := anObject
-]
-
-{ #category : #'private - filtering' }
-PqDatabaseBrowser >> keysSearchAccept: aString [
-
-	 aString isEmptyOrNil
-		ifTrue: [ self keysFilterPattern: nil ]
-		ifFalse: [ self keysFilterPattern: 
-					([ aString asRegexIgnoringCase ] on: RegexSyntaxError do: [ aString ])].
- 
-]
-
-{ #category : #'private - filtering' }
-PqDatabaseBrowser >> keysSearchField [
-
-	^ (SearchMorph new)
-			model: self;
-			setIndexSelector: #keysSearchAccept:; 
-			updateSelector: #keysSearchAccept:;
-			searchList: #();
-			asSpecAdapter
+	aWindowPresenter
+		title: self title;
+		initialExtent: 600@460;
+		whenClosedDo: [ self onWindowClosed ]
 ]
 
 { #category : #accessing }
-PqDatabaseBrowser >> menu [
-	^ menu
+PqDatabaseBrowser >> keysList [
+
+	^ keysList
 ]
 
-{ #category : #accessing }
-PqDatabaseBrowser >> menu: anObject [
-	menu := anObject
+{ #category : #'private - menus' }
+PqDatabaseBrowser >> keysListContextMenu [
+
+	^ self newMenu
+		addItem: [ :item |
+			item
+				name: 'Add entry';
+				action: [ self onAddEntry ] ];
+		addItem: [ :item |
+			item
+				name: 'Remove entry';
+				enabled: [ keysList selectedItem isNotNil ];
+				action: [ self onRemoveSelectedEntry ] ];
+		addItem: [ :item |
+			item
+				name: 'Edit entry';
+				enabled: [ keysList selectedItem isNotNil ];
+				action: [ self onEditEntry ] ];
+		yourself
 ]
 
 { #category : #'private - actions' }
 PqDatabaseBrowser >> onAddEntry [
-	|key value |
-	self database ifNil: [ ^self ].
-	
+	| key value |
+	self database ifNil: [ ^ self ].
+
 	key := UIManager default request: 'New key' initialAnswer: ''.
-	key ifNil: [ ^self ]. 
+	key ifNil: [ ^ self ].
 
 	value := UIManager default request: 'New value' initialAnswer: ''.
-	value ifNil: [ ^self ].
-	
+	value ifNil: [ ^ self ].
+
 	self database notNil ifTrue: [
 		self database transact: [
-			self database at: key put: value.
-		].
-		self updateKeysModel ]
+			self database at: key put: value ].
+		self updateKeysList ]
 ]
 
 { #category : #'private - actions' }
 PqDatabaseBrowser >> onEditEntry [
-	|key value |
-	self database ifNil: [ ^self ].
-	
-	key := self keysModel selectedItem.
-	key ifNil: [ ^self ].
-	
-	value := UIManager default request: 'New value for ', key initialAnswer: (database at: key).
-	value ifNil: [ ^self ].
-	
+	| key value |
+	self database ifNil: [ ^ self ].
+
+	key := keysList selectedItem.
+	key ifNil: [ ^ self ].
+
+	value := UIManager default
+		request: 'New value for ', key
+		initialAnswer: (database at: key).
+	value ifNil: [ ^ self ].
+
 	self database notNil ifTrue: [
 		self database transact: [
-			self database at: key put: value.
-		].
-		self updateValueModel ]
+			self database at: key put: value ].
+		self updateValueText ]
 ]
 
 { #category : #'private - events' }
 PqDatabaseBrowser >> onKeySelectionChanged [
-	self updateValueModel
+	self updateValueText
 ]
 
 { #category : #'private - actions' }
@@ -277,67 +205,76 @@ PqDatabaseBrowser >> onRemoveSelectedEntry [
 
 	self database notNil ifTrue: [
 		self database transact: [
-			self database removeKey: self keysModel selectedItem.
-			self keysModel resetSelection ].
-		self updateKeysModel ]
+			self database removeKey: keysList selectedItem.
+			keysList unselectAll ].
+		self updateKeysList ]
+]
+
+{ #category : #'private - events' }
+PqDatabaseBrowser >> onWindowClosed [
+
+	database ifNotNil: [
+		database close.
+		database := nil.
+		databaseFilename := nil ]
 ]
 
 { #category : #'private - utilities' }
 PqDatabaseBrowser >> openDatabase: filename [
 
- 
 	database := PqDatabase open: filename.
 	databaseFilename := filename.
-	self updateKeysModel.
-
-	self updateTitle.
+	self updateKeysList.
+	self updateTitle
 ]
 
 { #category : #'private - actions' }
 PqDatabaseBrowser >> openFile [
-    | filename |
-    filename := UITheme builder 
-                            fileOpen: 'Choose a .db file' 
-                            extensions: #('db').
-    filename isNil ifTrue:[ ^self ].
-    self openDatabase: filename name
-]
-
-{ #category : #'private - actions' }
-PqDatabaseBrowser >> openHelp [
-
-	HelpBrowser openOn: PqHelp asHelpTopic 
+	| filename |
+	filename := UITheme builder
+		fileOpen: 'Choose a .db file'
+		extensions: #('db').
+	filename isNil ifTrue:[ ^ self ].
+	self openDatabase: filename name
 ]
 
 { #category : #accessing }
 PqDatabaseBrowser >> title [
 
-	^databaseFilename ifNil: [ 'PUnQLite browser' ]
+	^ databaseFilename
+		ifNil: [ 'PunQLite browser' ]
 		ifNotNil: [ databaseFilename  ]
 ]
 
-{ #category : #'private - updating' }
-PqDatabaseBrowser >> updateKeysModel [
+{ #category : #accessing }
+PqDatabaseBrowser >> toolbar [
 
-	keysModel items: database keys sorted
+	^ toolbar
 ]
 
 { #category : #'private - updating' }
-PqDatabaseBrowser >> updateValueModel [
+PqDatabaseBrowser >> updateKeysList [
 
-	|key|
-	key := self keysModel selectedItem.
-	key 
-		ifNil: [ self valueModel text: '' ] 
-		ifNotNil: [ self valueModel text: (self database at: key) asString ]
+	keysList items: database keys sorted
+]
+
+{ #category : #'private - updating' }
+PqDatabaseBrowser >> updateTitle [
+
+	self withWindowDo: [ :window | window title: self title ]
+]
+
+{ #category : #'private - updating' }
+PqDatabaseBrowser >> updateValueText [
+	| key |
+	key := keysList selectedItem.
+	key
+		ifNil: [ valueText text: '' ]
+		ifNotNil: [ valueText text: (self database at: key) asString ]
 ]
 
 { #category : #accessing }
-PqDatabaseBrowser >> valueModel [
-	^ valueModel
-]
+PqDatabaseBrowser >> valueText [
 
-{ #category : #accessing }
-PqDatabaseBrowser >> valueModel: anObject [
-	valueModel := anObject
+	^ valueText
 ]


### PR DESCRIPTION
## Summary

Migrates the PqDatabaseBrowser from deprecated Spec1 (Pharo 7) to modern Spec2 API for compatibility with Pharo 13 and future Pharo versions.

## Motivation

The existing PqDatabaseBrowser used the legacy Spec1 framework (ComposableModel) which has been deprecated since Pharo 8 and replaced by Spec2. This migration is necessary to ensure PunQLite-Tools remains functional in current and future Pharo versions.

## Changes Made

- **Base Class Migration**: Changed from ComposableModel to SpPresenter
- **List with Filtering**: Replaced IconListModel + SearchMorph with SpFilteringListPresenter (provides built-in search functionality)
- **Toolbar**: Replaced MenuModel with SpToolbarPresenter
- **Layout System**: Migrated from SpecLayout to SpBoxLayout/SpPanedLayout
- **Initialization**: Converted initializeWidgets to initializePresenters
- **Removed Obsolete Code**: Cleaned up deprecated class-side spec methods and PqHelp reference

## Testing

- ✓ Tonel syntax validation passed
- ✓ Lint check: 5 minor warnings (acceptable)
- ✓ Successfully imported to Pharo 13 image
- ✓ Browser opens and displays database contents correctly
- ✓ Search/filter functionality works as expected

## Technical Details

- Uses SpFilteringListPresenter which eliminates the need for custom SearchMorph integration
- Modern window lifecycle management with proper initialization
- Cleaner code with reduced complexity (283 lines added, 343 lines removed)

## Files Changed

- repository/PunQLite-Tools/PqDatabaseBrowser.class.st (73% rewrite)

## Related

This migration follows the removal of the obsolete PunQLite-Help package (PR #8) which had references to old Spec1 help integration.