### PR TITLE
Add codec support for transparent object encoding/decoding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,13 @@ PunQLite-Core         # FFI bindings, low-level library interface
   ├─ UnQLiteLibrary   # Library loading and platform detection
   └─ UnQLiteConstants # C constants mapping
 
-PunQLite-DB           # High-level database API
+PunQLite-DB-Codec     # Pluggable codec system for value serialization
+  ├─ PqCodec          # Abstract codec base class
+  ├─ PqUtf8Codec      # UTF-8 string encoding (default)
+  ├─ PqJsonCodec      # JSON serialization via STONJSON
+  └─ PqFuelCodec      # Fuel binary serialization (preserves class types)
+
+PunQLite-DB           # High-level database API (depends on Core, DB-Codec)
   ├─ PqDatabase       # Main database interface (Dictionary-like API)
   ├─ PqCursor         # Cursor-based iteration
   ├─ PqCollection     # Collection interface
@@ -43,6 +49,13 @@ PunQLite-Tools        # Spec2 GUI browser (depends on PunQLite-DB)
 **Cursor-Based Iteration**: For efficient database scanning, use `PqCursor` which provides `seek:untilEndDo:` and standard iteration protocols.
 
 **Jx9 Integration**: Bidirectional conversion between Smalltalk objects and Jx9 values via extension methods (e.g., `String>>asJx9Value:`, `Integer>>asJx9Value:`). The `PqJx9Executer` manages script compilation and execution lifecycle.
+
+**Codec System**: Pluggable encoding/decoding for transparent object serialization. `PqCodec` defines the `encode:`/`decode:` protocol with three implementations:
+- `PqUtf8Codec` (default): UTF-8 string encoding
+- `PqJsonCodec`: JSON serialization for arrays/dictionaries
+- `PqFuelCodec`: Fuel binary serialization preserving class types
+
+Configure via `PqDatabase>>codec:` or globally via `PqSettings>>defaultCodecClassName:`.
 
 ## Native Library Management
 
@@ -132,9 +145,12 @@ Metacello new
 ## Testing
 
 Test packages are in `repository/PunQLite-Tests/`:
-- `PqDatabaseTest` - Core database operations
+- `PqDatabaseTest` - Core database operations and codec integration
 - `PqJx9Test` - Jx9 scripting integration
 - `PqCollectionTest` - Collection protocol
+- `PqCodecTest` - UTF-8 codec tests
+- `PqJsonCodecTest` - JSON codec tests
+- `PqFuelCodecTest` - Fuel codec tests
 
 All tests use in-memory databases (`PqDatabase openOnMemory`) to avoid file system dependencies.
 
@@ -172,6 +188,13 @@ The project uses **GitHub Actions** with SmalltalkCI for continuous integration:
 - Validates all packages on push and pull requests
 
 ## Recent Major Improvements
+
+### Codec System
+- **PunQLite-DB-Codec** package for pluggable value serialization
+- `PqUtf8Codec` (default), `PqJsonCodec`, `PqFuelCodec` implementations
+- `PqDatabase` codec support: `storeAt:valueEncoded:`, `fetchAt:intoDecoded:`
+- `PqCursor` codec support: `currentValueIntoDecoded:`
+- Global codec configuration via `PqSettings>>defaultCodecClassName:`
 
 ### GUI Migration
 - **PqDatabaseBrowser** migrated from Spec1 to Spec2

--- a/repository/BaselineOfPunQLite/BaselineOfPunQLite.class.st
+++ b/repository/BaselineOfPunQLite/BaselineOfPunQLite.class.st
@@ -14,14 +14,15 @@ BaselineOfPunQLite >> baseline: spec [
 
 		spec
 			package: 'PunQLite-Core';
-			package: 'PunQLite-DB' 		with: [ spec requires: #('PunQLite-Core' ) ];
+			package: 'PunQLite-DB-Codec';
+			package: 'PunQLite-DB' 		with: [ spec requires: #('PunQLite-Core' 'PunQLite-DB-Codec') ];
 			package: 'PunQLite-Jx9' 		with: [ spec requires: #('PunQLite-DB') ];
 			package: 'PunQLite-Tools' 	with: [ spec requires: #('PunQLite-DB') ];
-			package: 'PunQLite-Tests' 	with: [ spec requires: #('PunQLite-Jx9') ].
+			package: 'PunQLite-Tests' 	with: [ spec requires: #('PunQLite-Jx9' 'PunQLite-DB-Codec') ].
 
 		spec
 			group: 'default' with: #('Core' 'Tests');
-			group: 'Core' with: #('PunQLite-Core' 'PunQLite-DB' 'PunQLite-Jx9' );
+			group: 'Core' with: #('PunQLite-Core' 'PunQLite-DB-Codec' 'PunQLite-DB' 'PunQLite-Jx9' );
 			group: 'Tools' with: #('PunQLite-Tools');
 			group: 'Tests' with: #('PunQLite-Tests') ]
 ]

--- a/repository/PunQLite-Core/PqSettings.class.st
+++ b/repository/PunQLite-Core/PqSettings.class.st
@@ -61,6 +61,20 @@ PqSettings >> at: key put: value [
 ]
 
 { #category : 'accessing' }
+PqSettings >> defaultCodecClassName [
+	"Return the default codec class name for encoding/decoding database values"
+
+	^ self at: #defaultCodecClassName ifAbsentPut: [ #PqUtf8Codec ]
+]
+
+{ #category : 'accessing' }
+PqSettings >> defaultCodecClassName: aSymbol [
+	"Set the default codec class name for encoding/decoding database values"
+
+	^ self at: #defaultCodecClassName put: aSymbol
+]
+
+{ #category : 'accessing' }
 PqSettings >> defaultFetchBufferSize [
 	^self at: #defaultFetchBufferSize ifAbsentPut: [1024]
 ]

--- a/repository/PunQLite-DB-Codec/PqCodec.class.st
+++ b/repository/PunQLite-DB-Codec/PqCodec.class.st
@@ -1,0 +1,39 @@
+"
+I am an abstract codec for encoding/decoding values stored in PunQLite database.
+
+Responsibility:
+- Define the encoding/decoding protocol for PqDatabase values
+- Subclasses implement specific encoding strategies (UTF-8, JSON, etc.)
+
+Collaborators:
+- PqDatabase: Uses codecs for value encoding/decoding
+- PqCursor: Uses codecs for decoding values during iteration
+
+Public API and Key Messages:
+- #encode: anObject - Convert an object to ByteArray (subclassResponsibility)
+- #decode: aByteArray - Convert ByteArray back to an object (subclassResponsibility)
+
+Example:
+  codec := PqUtf8Codec new.
+  encoded := codec encode: 'Hello, 世界'.
+  decoded := codec decode: encoded.  ""=> 'Hello, 世界'""
+"
+Class {
+	#name : #PqCodec,
+	#superclass : #Object,
+	#category : #'PunQLite-DB-Codec'
+}
+
+{ #category : #encoding }
+PqCodec >> decode: aByteArray [
+	"Decode a ByteArray back to an object"
+
+	^ self subclassResponsibility
+]
+
+{ #category : #encoding }
+PqCodec >> encode: anObject [
+	"Encode an object to a ByteArray"
+
+	^ self subclassResponsibility
+]

--- a/repository/PunQLite-DB-Codec/PqFuelCodec.class.st
+++ b/repository/PunQLite-DB-Codec/PqFuelCodec.class.st
@@ -1,0 +1,46 @@
+"
+I encode and decode arbitrary objects using Fuel binary serialization.
+
+Responsibility:
+- Convert arbitrary Smalltalk objects to Fuel-serialized ByteArrays
+- Convert Fuel-serialized ByteArrays back to Smalltalk objects
+
+Collaborators:
+- FLSerializer: Used for binary serialization
+- FLMaterializer: Used for binary deserialization
+- PqCodec: My superclass defining the encoding protocol
+- PqDatabase: Used when storing complex Smalltalk objects
+
+Public API and Key Messages:
+- #encode: anObject - Serialize object to ByteArray using Fuel
+- #decode: aByteArray - Deserialize ByteArray to object using Fuel
+
+Example:
+  codec := PqFuelCodec new.
+  encoded := codec encode: (OrderedCollection with: 1 with: 2 with: 3).
+  decoded := codec decode: encoded.  ""=> an OrderedCollection(1 2 3)""
+
+  ""Fuel preserves object identity and class types""
+  original := Set with: 'a' with: 'b'.
+  decoded := codec decode: (codec encode: original).
+  decoded class = Set.  ""=> true""
+"
+Class {
+	#name : #PqFuelCodec,
+	#superclass : #PqCodec,
+	#category : #'PunQLite-DB-Codec'
+}
+
+{ #category : #encoding }
+PqFuelCodec >> decode: aByteArray [
+	"Deserialize a Fuel-encoded ByteArray to a Smalltalk object"
+
+	^ FLMaterializer materializeFromByteArray: aByteArray
+]
+
+{ #category : #encoding }
+PqFuelCodec >> encode: anObject [
+	"Serialize a Smalltalk object to a Fuel-encoded ByteArray"
+
+	^ FLSerializer serializeToByteArray: anObject
+]

--- a/repository/PunQLite-DB-Codec/PqJsonCodec.class.st
+++ b/repository/PunQLite-DB-Codec/PqJsonCodec.class.st
@@ -1,0 +1,43 @@
+"
+I encode and decode arbitrary objects using JSON serialization.
+
+Responsibility:
+- Convert arbitrary Smalltalk objects to JSON-encoded UTF-8 ByteArrays
+- Convert JSON-encoded ByteArrays back to Smalltalk objects
+
+Collaborators:
+- STONJSON: Used for JSON serialization/deserialization
+- PqUtf8Codec: My superclass providing UTF-8 encoding
+- PqDatabase: Used when storing complex objects (arrays, dictionaries)
+
+Public API and Key Messages:
+- #encode: anObject - Convert object to JSON, then to UTF-8 ByteArray
+- #decode: aByteArray - Decode UTF-8 to JSON string, then parse to object
+
+Example:
+  codec := PqJsonCodec new.
+  encoded := codec encode: #('Alice' 'Bob' 'Charlie').
+  decoded := codec decode: encoded.  ""=> #('Alice' 'Bob' 'Charlie')""
+
+  encoded := codec encode: (Dictionary new at: 'name' put: 'Alice'; yourself).
+  decoded := codec decode: encoded.  ""=> a Dictionary('name'->'Alice')""
+"
+Class {
+	#name : #PqJsonCodec,
+	#superclass : #PqUtf8Codec,
+	#category : #'PunQLite-DB-Codec'
+}
+
+{ #category : #encoding }
+PqJsonCodec >> decode: aByteArray [
+	"Decode a JSON-encoded UTF-8 ByteArray to a Smalltalk object"
+
+	^ STONJSON fromString: (super decode: aByteArray)
+]
+
+{ #category : #encoding }
+PqJsonCodec >> encode: anObject [
+	"Encode a Smalltalk object to a JSON-encoded UTF-8 ByteArray"
+
+	^ super encode: (STONJSON toString: anObject)
+]

--- a/repository/PunQLite-DB-Codec/PqUtf8Codec.class.st
+++ b/repository/PunQLite-DB-Codec/PqUtf8Codec.class.st
@@ -1,0 +1,39 @@
+"
+I encode and decode string values using UTF-8 encoding.
+
+Responsibility:
+- Convert strings to UTF-8 encoded ByteArrays
+- Convert UTF-8 ByteArrays back to strings
+
+Collaborators:
+- PqDatabase: Default codec for string storage
+- PqCodec: My superclass defining the encoding protocol
+
+Public API and Key Messages:
+- #encode: anObject - Convert string to UTF-8 ByteArray
+- #decode: aByteArray - Convert UTF-8 ByteArray to string
+
+Example:
+  codec := PqUtf8Codec new.
+  encoded := codec encode: 'Hello, 世界'.
+  decoded := codec decode: encoded.  ""=> 'Hello, 世界'""
+"
+Class {
+	#name : #PqUtf8Codec,
+	#superclass : #PqCodec,
+	#category : #'PunQLite-DB-Codec'
+}
+
+{ #category : #encoding }
+PqUtf8Codec >> decode: aByteArray [
+	"Decode a UTF-8 ByteArray to a string"
+
+	^ aByteArray utf8Decoded
+]
+
+{ #category : #encoding }
+PqUtf8Codec >> encode: anObject [
+	"Encode an object to a UTF-8 ByteArray"
+
+	^ anObject utf8Encoded
+]

--- a/repository/PunQLite-DB-Codec/package.st
+++ b/repository/PunQLite-DB-Codec/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'PunQLite-DB-Codec' }

--- a/repository/PunQLite-DB/PqCursor.class.st
+++ b/repository/PunQLite-DB/PqCursor.class.st
@@ -216,6 +216,39 @@ PqCursor >> currentValueInto: aBlock [
 ]
 
 { #category : #'accessig value' }
+PqCursor >> currentValueInto: aBlock by: aCodec [
+	"Fetch the current value, decode it using the specified codec, and pass to aBlock.
+
+	This method uses callback-based retrieval to avoid buffer size limitations.
+	"
+	| wrappedBlock |
+
+	wrappedBlock := [ :dataAddr :dataSize :userData | | ret |
+		ret := OK.
+		[ | data decodedData |
+			data := dataAddr copyFrom: 1 to: dataSize.
+			decodedData := aCodec decode: data.
+			aBlock cull: decodedData cull: userData
+		]
+		on: Error
+		do: [ :ex | ret := ABORT ].
+		ret
+	].
+
+	^ self currentValueBasicInto: wrappedBlock
+]
+
+{ #category : #'accessig value' }
+PqCursor >> currentValueIntoDecoded: aBlock [
+	"Fetch the current value, decode it using the database's default codec, and pass to aBlock.
+
+	This method uses the codec configured on the associated database.
+	"
+
+	^ self currentValueInto: aBlock by: self database codec
+]
+
+{ #category : #'accessig value' }
 PqCursor >> currentValueSized: valueBufferSize [
 	| intHolder ourBytes ret |
 	intHolder := UnQLiteFFI newIntHolder: valueBufferSize.

--- a/repository/PunQLite-DB/PqCursor.class.st
+++ b/repository/PunQLite-DB/PqCursor.class.st
@@ -7,11 +7,13 @@ Responsibility:
 - Enable seeking to specific keys with exact match, greater-than, or less-than semantics
 - Allow reading and deletion of entries at the current cursor position
 - Implement standard Smalltalk enumeration protocol (do:, reverseDo:)
+- Support codec-based value decoding during iteration
 
 Collaborators:
-- PqDatabase: The database I iterate over, provides handle and settings
+- PqDatabase: The database I iterate over, provides handle, settings, and codec
 - UnQLiteFFI: Makes low-level cursor FFI calls (init, seek, next, prev, release)
 - UnQLiteFetchCallback: Used for callback-based data retrieval
+- PqCodec: Decodes values when using codec-aware retrieval methods
 - UnQLiteConstants: Provides cursor positioning constants (CURSOR_MATCH_*)
 
 Public API and Key Messages:
@@ -25,6 +27,8 @@ Public API and Key Messages:
 - #seek:untilEndDo: - Seek to key and iterate forward from there
 - #currentKey, #currentValue - Read data at current position
 - #currentStringKey, #currentStringValue - Read as strings
+- #currentValueIntoDecoded: - Read and decode value using database's codec
+- #currentValueInto:by: - Read and decode value using specified codec
 - #deleteCurrent - Delete entry at current position
 - #close - Release cursor resources
 
@@ -42,6 +46,14 @@ Example:
       ""Iterates over 'banana' and 'cherry'""
       Transcript show: c currentStringKey; cr]].
 
+  ""Codec-based iteration""
+  db := PqDatabase openOnMemory.
+  db codec: PqJsonCodec new.
+  db storeAt: 'data' valueEncoded: #('a' 'b' 'c').
+  db cursorDo: [:cursor |
+    cursor do: [:c |
+      c currentValueIntoDecoded: [:value | Transcript show: value printString; cr]]].
+
 Internal Representation:
 - database - The PqDatabase being iterated
 - handle - Native unqlite_kv_cursor* pointer (inherited from PqObject)
@@ -55,6 +67,7 @@ Implementation Points:
 - CURSOR_MATCH_GE and CURSOR_MATCH_LE provide range query support
 - Callback-based retrieval is available via #currentKeyInto: and #currentValueInto:
 - Buffer size for key/value retrieval defaults to database's fetchBufferSize
+- Codec for decoding is obtained from the associated database instance
 "
 Class {
 	#name : #PqCursor,

--- a/repository/PunQLite-DB/PqDatabase.class.st
+++ b/repository/PunQLite-DB/PqDatabase.class.st
@@ -60,6 +60,9 @@ Implementation Points:
 Class {
 	#name : #PqDatabase,
 	#superclass : #PqObject,
+	#instVars : [
+		'codec'
+	],
 	#category : #'PunQLite-DB-Base'
 }
 
@@ -152,6 +155,21 @@ PqDatabase >> close [
 	self isOpen ifFalse: [ ^self ].
 	(self isOk: (self ffi close: self handle))
 		ifTrue: [handleIsValid := false]
+]
+
+{ #category : #accessing }
+PqDatabase >> codec [
+	"Lazy initialization of codec from settings"
+
+	^ codec ifNil: [
+		codec := (self settings defaultCodecClassName asClassIfAbsent: [ PqUtf8Codec ]) new ]
+]
+
+{ #category : #accessing }
+PqDatabase >> codec: aCodec [
+	"Set a custom codec for this database instance"
+
+	codec := aCodec
 ]
 
 { #category : #accessing }
@@ -259,6 +277,38 @@ PqDatabase >> fetchAt: key into: aBlock [
 	^ self fetchAt: key basicInto: wrappedBlock
 ]
 
+{ #category : #'actions-codec' }
+PqDatabase >> fetchAt: key into: aBlock by: aCodec [
+	"Fetch a value by key and decode it using the specified codec.
+
+	The decoded value is passed to aBlock for processing.
+	Important: Uses the correct byte size after UTF-8 encoding for the key.
+	"
+	| wrappedBlock |
+
+	wrappedBlock := [ :dataAddr :dataSize :userData | | ret |
+		ret := OK.
+		[ | data decodedData |
+			data := dataAddr copyFrom: 1 to: dataSize.
+			decodedData := aCodec decode: data.
+			aBlock cull: decodedData cull: userData ]
+		on: Error
+		do: [ :ex | ret := ABORT ].
+		ret ].
+
+	^ self fetchAt: key basicInto: wrappedBlock
+]
+
+{ #category : #'actions-codec' }
+PqDatabase >> fetchAt: key intoDecoded: aBlock [
+	"Fetch and decode a value using the database's default codec.
+
+	This method uses the codec configured for this database instance.
+	"
+
+	^ self fetchAt: key into: aBlock by: self codec
+]
+
 { #category : #actions }
 PqDatabase >> fetchAt: key sized: valueBufSize [
 	"Fetch a value by key as a byte array.
@@ -292,26 +342,9 @@ PqDatabase >> fetchStringAt: key [
 
 { #category : #actions }
 PqDatabase >> fetchStringAt: key sized: valueBufSize [
-	"Fetch a string value by key with automatic UTF-8 decoding.
+	"Fetch a string value by key with automatic UTF-8 decoding"
 
-	Important: Uses the correct byte size after UTF-8 encoding for the key.
-	"
-	| intHolder ourStr ret keyBytes |
-
-	keyBytes := self toByteArray: key.
-	intHolder := UnQLiteFFI newIntHolder: valueBufSize.
-	ourStr := (ExternalAddress gcallocate: valueBufSize) autoRelease.
-	ret := self ffi
-		fetch: self handle
-		key: keyBytes
-		sized: keyBytes size
-		value: ourStr
-		sized: intHolder.
-
-	(self isOk: ret) ifFalse: [
-		(PqFetchError code: ret key: key) signal ].
-
-	^ (ourStr copyFrom: 1 to: intHolder value) utf8Decoded
+	^ (self fetchAt: key sized: valueBufSize) utf8Decoded
 ]
 
 { #category : #'system-info' }
@@ -502,6 +535,36 @@ PqDatabase >> storeAt: key value: value [
 		value: valueBytes
 		sized: valueBytes size.
 	^ self isOk: ret
+]
+
+{ #category : #'actions-codec' }
+PqDatabase >> storeAt: key value: anObject by: aCodec [
+	"Store a value at the given key using the specified codec.
+
+	The value (anObject) is encoded with aCodec before storing.
+	Important: Uses the correct byte size after UTF-8 encoding, not character count.
+	"
+	| ret keyBytes valueBytes |
+
+	keyBytes := self toByteArray: key.
+	valueBytes := aCodec encode: anObject.
+	ret := self ffi
+		store: self handle
+		key: keyBytes
+		sized: keyBytes size
+		value: valueBytes
+		sized: valueBytes size.
+	^ self isOk: ret
+]
+
+{ #category : #'actions-codec' }
+PqDatabase >> storeAt: key valueEncoded: anObject [
+	"Store an encoded value using the database's default codec.
+
+	This method uses the codec configured for this database instance.
+	"
+
+	^ self storeAt: key value: anObject by: self codec
 ]
 
 { #category : #transactions }

--- a/repository/PunQLite-DB/PqDatabase.class.st
+++ b/repository/PunQLite-DB/PqDatabase.class.st
@@ -8,6 +8,7 @@ Responsibility:
 - Create and manage cursors for efficient iteration
 - Provide access to Jx9 scripting engine and JSON document collections
 - Handle data marshalling between Smalltalk objects and byte arrays
+- Support pluggable codecs for transparent object serialization
 
 Collaborators:
 - UnQLiteFFI: Makes low-level FFI calls for all database operations
@@ -15,6 +16,7 @@ Collaborators:
 - PqCollection: Created via #collectionName: for JSON document storage
 - PqJx9Executer: Created via #jx9 for Jx9 script execution
 - PqValueAppender: Created via #appenderAt: for efficient value appending
+- PqCodec: Encodes/decodes values (PqUtf8Codec, PqJsonCodec, PqFuelCodec)
 - UnQLiteConstants: Provides mode constants and return codes
 
 Public API and Key Messages:
@@ -28,6 +30,11 @@ Public API and Key Messages:
 - #newCursor - Create a cursor for efficient scanning
 - #transact: - Execute a block within a manual transaction
 - #close - Close database and release native resources
+- #codec, #codec: - Get/set the codec for value encoding/decoding
+- #storeAt:valueEncoded: - Store a value using the default codec
+- #fetchAt:intoDecoded: - Fetch and decode a value using the default codec
+- #storeAt:value:by: - Store a value using a specified codec
+- #fetchAt:into:by: - Fetch and decode a value using a specified codec
 
 Example:
   ""Basic key-value operations""
@@ -44,9 +51,17 @@ Example:
   db cursorDo: [:cursor |
     cursor do: [:c | Transcript show: c currentStringKey, ' => ', c currentStringValue; cr]].
 
+  ""Using codec for object serialization""
+  db := PqDatabase openOnMemory.
+  db codec: PqJsonCodec new.
+  db storeAt: 'users' valueEncoded: #('Alice' 'Bob' 'Charlie').
+  db fetchAt: 'users' intoDecoded: [:users | users do: [:u | Transcript show: u; cr]].
+  db close.
+
 Internal Representation:
 - Inherits handle from PqObject - points to unqlite* database handle
 - handleIsValid - tracks whether database is open
+- codec - PqCodec instance for value encoding/decoding (lazy initialized)
 
 Implementation Points:
 - Keys and values are stored as byte arrays (UTF-8 for strings)
@@ -56,6 +71,7 @@ Implementation Points:
 - Always call #close to release native resources (use #ensure: in production)
 - Cursors become invalid after database modifications
 - Fetch operations may need larger buffer sizes for large values (see #fetchBufferSize:)
+- Default codec is PqUtf8Codec, configurable via PqSettings>>defaultCodecClassName
 "
 Class {
 	#name : #PqDatabase,

--- a/repository/PunQLite-Tests/PqCodecTest.class.st
+++ b/repository/PunQLite-Tests/PqCodecTest.class.st
@@ -1,0 +1,51 @@
+"
+Tests for PqCodec and PqUtf8Codec classes.
+"
+Class {
+	#name : #PqCodecTest,
+	#superclass : #TestCase,
+	#category : #'PunQLite-Tests-Codec'
+}
+
+{ #category : #testing }
+PqCodecTest >> testUtf8CodecDecodeByteArray [
+	| codec decoded |
+
+	codec := PqUtf8Codec new.
+	decoded := codec decode: 'Hello' utf8Encoded.
+	self assert: decoded equals: 'Hello'
+]
+
+{ #category : #testing }
+PqCodecTest >> testUtf8CodecEncodeString [
+	| codec encoded |
+
+	codec := PqUtf8Codec new.
+	encoded := codec encode: 'Hello'.
+	self assert: encoded equals: 'Hello' utf8Encoded
+]
+
+{ #category : #testing }
+PqCodecTest >> testUtf8CodecMultiByteCharacters [
+	| codec japanese chinese emoji |
+
+	codec := PqUtf8Codec new.
+
+	japanese := 'こんにちは'.
+	self assert: (codec decode: (codec encode: japanese)) equals: japanese.
+
+	chinese := '你好世界'.
+	self assert: (codec decode: (codec encode: chinese)) equals: chinese.
+
+	emoji := '👋🌍'.
+	self assert: (codec decode: (codec encode: emoji)) equals: emoji
+]
+
+{ #category : #testing }
+PqCodecTest >> testUtf8CodecRoundtrip [
+	| codec original |
+
+	codec := PqUtf8Codec new.
+	original := 'Hello, 世界! 👋'.
+	self assert: (codec decode: (codec encode: original)) equals: original
+]

--- a/repository/PunQLite-Tests/PqDatabaseTest.class.st
+++ b/repository/PunQLite-Tests/PqDatabaseTest.class.st
@@ -815,3 +815,144 @@ PqDatabaseTest >> testMultiByteStringCursor [
 	cursor close.
 	self deny: cursor isOpen
 ]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testCodecAccessor [
+	"self debug: #testCodecAccessor"
+
+	self assert: self database codec class equals: PqUtf8Codec.
+
+	self database codec: PqJsonCodec new.
+	self assert: self database codec class equals: PqJsonCodec
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testCursorValueIntoByCodec [
+	"self debug: #testCursorValueIntoByCodec"
+	| ok cursor decoded |
+
+	ok := self database storeAt: 'users' value: #('Alice' 'Bob') by: PqJsonCodec new.
+	self assert: ok.
+
+	cursor := self database newCursor.
+	cursor first.
+
+	cursor currentValueInto: [ :value | decoded := value ] by: PqJsonCodec new.
+	self assert: decoded equals: #('Alice' 'Bob').
+
+	cursor close
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testCursorValueIntoDecoded [
+	"self debug: #testCursorValueIntoDecoded"
+	| ok cursor decoded |
+
+	self database codec: PqJsonCodec new.
+	ok := self database storeAt: 'config' valueEncoded: (Dictionary new at: 'timeout' put: 30; yourself).
+	self assert: ok.
+
+	cursor := self database newCursor.
+	cursor first.
+
+	cursor currentValueIntoDecoded: [ :value | decoded := value ].
+	self assert: (decoded at: 'timeout') equals: 30.
+
+	cursor close
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testFetchIntoByCodec [
+	"self debug: #testFetchIntoByCodec"
+	| ok decoded |
+
+	ok := self database storeAt: 'data' value: #(1 2 3) by: PqJsonCodec new.
+	self assert: ok.
+
+	self database fetchAt: 'data' into: [ :value | decoded := value ] by: PqJsonCodec new.
+	self assert: decoded equals: #(1 2 3)
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testFetchIntoDecoded [
+	"self debug: #testFetchIntoDecoded"
+	| ok decoded |
+
+	self database codec: PqJsonCodec new.
+	ok := self database storeAt: 'list' valueEncoded: #('a' 'b' 'c').
+	self assert: ok.
+
+	self database fetchAt: 'list' intoDecoded: [ :value | decoded := value ].
+	self assert: decoded equals: #('a' 'b' 'c')
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testJsonCodecIntegration [
+	"self debug: #testJsonCodecIntegration"
+	| ok decoded |
+
+	self database codec: PqJsonCodec new.
+
+	ok := self database storeAt: 'users' valueEncoded: #('Alice' 'Bob' 'Charlie').
+	self assert: ok.
+
+	ok := self database storeAt: 'config' valueEncoded: (Dictionary new at: 'timeout' put: 30; at: 'retries' put: 3; yourself).
+	self assert: ok.
+
+	self database fetchAt: 'users' intoDecoded: [ :value | decoded := value ].
+	self assert: decoded equals: #('Alice' 'Bob' 'Charlie').
+
+	self database fetchAt: 'config' intoDecoded: [ :value | decoded := value ].
+	self assert: (decoded at: 'timeout') equals: 30.
+	self assert: (decoded at: 'retries') equals: 3
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testStoreValueByCodec [
+	"self debug: #testStoreValueByCodec"
+	| ok fetched |
+
+	ok := self database storeAt: 'data' value: #(1 2 3) by: PqJsonCodec new.
+	self assert: ok.
+
+	fetched := self database fetchStringAt: 'data'.
+	self assert: fetched equals: '[1,2,3]'
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testStoreValueEncoded [
+	"self debug: #testStoreValueEncoded"
+	| ok fetched |
+
+	self database codec: PqJsonCodec new.
+	ok := self database storeAt: 'list' valueEncoded: #('a' 'b' 'c').
+	self assert: ok.
+
+	fetched := self database fetchStringAt: 'list'.
+	self assert: fetched equals: '["a","b","c"]'
+]
+
+{ #category : 'testing-codec' }
+PqDatabaseTest >> testCustomSettingsCodecClassName [
+	"Test that defaultCodecClassName in custom settings controls the database codec"
+	"self debug: #testCustomSettingsCodecClassName"
+	| db customSettings ok decoded |
+
+	customSettings := PqSettings new.
+	customSettings defaultCodecClassName: #PqJsonCodec.
+
+	db := PqDatabase openOnMemory.
+	[
+		db settings: customSettings.
+
+		"Verify codec is created from settings"
+		self assert: db codec class equals: PqJsonCodec.
+
+		"Test actual encoding/decoding"
+		ok := db storeAt: 'data' valueEncoded: #('x' 'y' 'z').
+		self assert: ok.
+
+		db fetchAt: 'data' intoDecoded: [ :value | decoded := value ].
+		self assert: decoded equals: #('x' 'y' 'z')
+	] ensure: [ db close ]
+]

--- a/repository/PunQLite-Tests/PqFuelCodecTest.class.st
+++ b/repository/PunQLite-Tests/PqFuelCodecTest.class.st
@@ -1,0 +1,87 @@
+"
+Tests for PqFuelCodec class.
+"
+Class {
+	#name : #PqFuelCodecTest,
+	#superclass : #TestCase,
+	#category : #'PunQLite-Tests-Codec'
+}
+
+{ #category : #testing }
+PqFuelCodecTest >> testFuelCodecDecodeByteArray [
+	| codec original encoded decoded |
+
+	codec := PqFuelCodec new.
+	original := #(1 2 3).
+	encoded := FLSerializer serializeToByteArray: original.
+	decoded := codec decode: encoded.
+	self assert: decoded equals: original
+]
+
+{ #category : #testing }
+PqFuelCodecTest >> testFuelCodecEncodeArray [
+	| codec encoded decoded |
+
+	codec := PqFuelCodec new.
+	encoded := codec encode: #('a' 'b' 'c').
+	decoded := FLMaterializer materializeFromByteArray: encoded.
+	self assert: decoded equals: #('a' 'b' 'c')
+]
+
+{ #category : #testing }
+PqFuelCodecTest >> testFuelCodecPreservesClass [
+	| codec original decoded |
+
+	codec := PqFuelCodec new.
+
+	"OrderedCollection"
+	original := OrderedCollection with: 1 with: 2 with: 3.
+	decoded := codec decode: (codec encode: original).
+	self assert: decoded class equals: OrderedCollection.
+	self assert: decoded asArray equals: #(1 2 3).
+
+	"Set"
+	original := Set with: 'x' with: 'y'.
+	decoded := codec decode: (codec encode: original).
+	self assert: decoded class equals: Set.
+	self assert: (decoded includes: 'x').
+	self assert: (decoded includes: 'y')
+]
+
+{ #category : #testing }
+PqFuelCodecTest >> testFuelCodecRoundtripArray [
+	| codec original |
+
+	codec := PqFuelCodec new.
+	original := #(1 2 3 'hello' true).
+	self assert: (codec decode: (codec encode: original)) equals: original
+]
+
+{ #category : #testing }
+PqFuelCodecTest >> testFuelCodecRoundtripDictionary [
+	| codec original decoded |
+
+	codec := PqFuelCodec new.
+	original := Dictionary new
+		at: 'name' put: 'Alice';
+		at: 'age' put: 30;
+		yourself.
+	decoded := codec decode: (codec encode: original).
+	self assert: (decoded at: 'name') equals: 'Alice'.
+	self assert: (decoded at: 'age') equals: 30
+]
+
+{ #category : #testing }
+PqFuelCodecTest >> testFuelCodecRoundtripNested [
+	| codec original decoded |
+
+	codec := PqFuelCodec new.
+	original := Dictionary new
+		at: 'users' put: (OrderedCollection with: 'Alice' with: 'Bob');
+		at: 'config' put: (Dictionary new at: 'timeout' put: 30; yourself);
+		yourself.
+	decoded := codec decode: (codec encode: original).
+	self assert: (decoded at: 'users') class equals: OrderedCollection.
+	self assert: (decoded at: 'users') asArray equals: #('Alice' 'Bob').
+	self assert: ((decoded at: 'config') at: 'timeout') equals: 30
+]

--- a/repository/PunQLite-Tests/PqJsonCodecTest.class.st
+++ b/repository/PunQLite-Tests/PqJsonCodecTest.class.st
@@ -1,0 +1,82 @@
+"
+Tests for PqJsonCodec class.
+"
+Class {
+	#name : #PqJsonCodecTest,
+	#superclass : #TestCase,
+	#category : #'PunQLite-Tests-Codec'
+}
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecDecodeArray [
+	| codec decoded |
+
+	codec := PqJsonCodec new.
+	decoded := codec decode: '["Alice","Bob","Charlie"]' utf8Encoded.
+	self assert: decoded equals: #('Alice' 'Bob' 'Charlie')
+]
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecDecodeDictionary [
+	| codec decoded |
+
+	codec := PqJsonCodec new.
+	decoded := codec decode: '{"name":"Alice","age":30}' utf8Encoded.
+	self assert: (decoded at: 'name') equals: 'Alice'.
+	self assert: (decoded at: 'age') equals: 30
+]
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecEncodeArray [
+	| codec encoded |
+
+	codec := PqJsonCodec new.
+	encoded := codec encode: #('Alice' 'Bob' 'Charlie').
+	self assert: encoded equals: '["Alice","Bob","Charlie"]' utf8Encoded
+]
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecEncodeDictionary [
+	| codec encoded decoded |
+
+	codec := PqJsonCodec new.
+	encoded := codec encode: (Dictionary new at: 'name' put: 'Alice'; yourself).
+	decoded := STONJSON fromString: encoded utf8Decoded.
+	self assert: (decoded at: 'name') equals: 'Alice'
+]
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecRoundtripArray [
+	| codec original |
+
+	codec := PqJsonCodec new.
+	original := #('Alice' 'Bob' 'Charlie').
+	self assert: (codec decode: (codec encode: original)) equals: original
+]
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecRoundtripComplex [
+	| codec original decoded |
+
+	codec := PqJsonCodec new.
+	original := Dictionary new
+		at: 'users' put: #('Alice' 'Bob');
+		at: 'count' put: 2;
+		at: 'active' put: true;
+		yourself.
+	decoded := codec decode: (codec encode: original).
+	self assert: (decoded at: 'users') equals: #('Alice' 'Bob').
+	self assert: (decoded at: 'count') equals: 2.
+	self assert: (decoded at: 'active') equals: true
+]
+
+{ #category : #testing }
+PqJsonCodecTest >> testJsonCodecRoundtripDictionary [
+	| codec original decoded |
+
+	codec := PqJsonCodec new.
+	original := Dictionary new at: 'name' put: 'Alice'; at: 'age' put: 30; yourself.
+	decoded := codec decode: (codec encode: original).
+	self assert: (decoded at: 'name') equals: 'Alice'.
+	self assert: (decoded at: 'age') equals: 30
+]


### PR DESCRIPTION
## Summary

Introduce a pluggable codec system for PqDatabase that enables transparent encoding/decoding of arbitrary Smalltalk objects. This allows storing and retrieving complex data structures (arrays, dictionaries, custom objects) without manual serialization.

## New Features

### Codec Classes (PunQLite-DB-Codec)
- **PqCodec** - Abstract base class defining `encode:` / `decode:` protocol
- **PqUtf8Codec** - UTF-8 string encoding (default)
- **PqJsonCodec** - JSON serialization via STONJSON
- **PqFuelCodec** - Fuel binary serialization (preserves class types)

### PqDatabase Extensions
- `codec` / `codec:` - Get/set codec (lazy initialization from settings)
- `storeAt:valueEncoded:` / `fetchAt:intoDecoded:` - Store/fetch using default codec
- `storeAt:value:by:` / `fetchAt:into:by:` - Store/fetch using specified codec

### PqCursor Extensions
- `currentValueIntoDecoded:` - Decode value using database's default codec
- `currentValueInto:by:` - Decode value using specified codec

### PqSettings Extensions
- `defaultCodecClassName` / `defaultCodecClassName:` - Global codec configuration

## Refactoring
- `fetchStringAt:sized:` now reuses `fetchAt:sized:` to reduce code duplication

## Documentation
- Updated class comments for PqDatabase and PqCursor
- Updated README.md with codec usage examples
- Updated CLAUDE.md with package structure and design patterns

## Files Changed

| File | Changes |
|------|---------|
| PunQLite-DB-Codec/ | New package (4 classes + package.st) |
| PqDatabase.class.st | Codec support + updated class comment |
| PqCursor.class.st | Codec methods + updated class comment |
| PqSettings.class.st | defaultCodecClassName accessor |
| BaselineOfPunQLite.class.st | New package dependency |
| PqCodecTest.class.st | 4 tests |
| PqJsonCodecTest.class.st | 7 tests |
| PqFuelCodecTest.class.st | 6 tests |
| PqDatabaseTest.class.st | 9 codec integration tests |
| README.md | Codec usage examples |
| CLAUDE.md | Architecture and design documentation |

## Test Results
- 79 tests passed (26 new codec-related tests)

## Usage Example

```smalltalk
"Using JSON codec"
db := PqDatabase openOnMemory.
db codec: PqJsonCodec new.

db storeAt: 'users' valueEncoded: #('Alice' 'Bob' 'Charlie').
db fetchAt: 'users' intoDecoded: [:users |
    users do: [:name | Transcript show: name; cr]].

db close.

"Using Fuel codec (preserves class types)"
db := PqDatabase openOnMemory.
db codec: PqFuelCodec new.

db storeAt: 'items' valueEncoded: (OrderedCollection with: 1 with: 2).
db fetchAt: 'items' intoDecoded: [:items |
    items class = OrderedCollection].  "=> true"

db close.
```